### PR TITLE
attribution is not always correct for pull requests

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -287,8 +287,10 @@ var getCommitsInMerge = function(mergeCommit) {
   var store2 = {};
 
   var getAllReachableCommits = function(sha, store) {
+    if (!commitsBySha[sha]) return;
     store[sha]=true;
     commitsBySha[sha].parents.forEach(function(parent){
+      if (store[parent.sha]) return; // don't revist commits we've explored
       return getAllReachableCommits(parent.sha, store);
     })
   };


### PR DESCRIPTION
this is because we don't have enough information in just the merge commit. We need to explore all the commits in the branch and give credit to all the authors who have a commit in the branch.

Relying on the user name from the commit message is especially invalid for organization accounts.

Note: Should be fine for `--data pulls`

Issue was discovered in #20 thanks.
