### PR TITLE
handle missing author in pull requests

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -315,7 +315,7 @@ var commitFormatter = function(data) {
   var output = "## Change Log\n";
   data.forEach(function(commit){
     var isMerge = (commit.parents.length > 1);
-    var isPull = /^Merge pull request #/i.test(commit.commit.message);
+    var isPull = isMerge && /^Merge pull request #/i.test(commit.commit.message);
     // exits
     if ((opts.merges === false) && isMerge) return '';
     if ((opts['only-merges']) && commit.parents.length < 2) return '';
@@ -365,7 +365,7 @@ var commitFormatter = function(data) {
     // if it's a pull request, then the link should be to the pull request
     if (isPull) {
       var prNumber = commit.commit.message.split('#')[1].split(' ')[0];
-      var author = commit.commit.message.split(/\#\d+\sfrom\s/)[1].split('/')[0];
+      var author = (commit.commit.message.split(/\#\d+\sfrom\s/)[1]||'').split('/')[0];
       var url = "https://github.com/"+opts.owner+"/"+opts.repository+"/pull/"+prNumber;
       output += "- [#" + prNumber + "](" + url + ") " + message;
 


### PR DESCRIPTION
```
error [TypeError: Cannot call method 'split' of undefined]
stack TypeError: Cannot call method 'split' of undefined
    at /Users/lalit/.nvm/v0.10.24/lib/node_modules/github-changes/bin/index.js:368:68
    at Array.forEach (native)
    at commitFormatter (/Users/lalit/.nvm/v0.10.24/lib/node_modules/github-changes/bin/index.js:316:8)
    at formatter (/Users/lalit/.nvm/v0.10.24/lib/node_modules/github-changes/bin/index.js:392:39)
    at /Users/lalit/.nvm/v0.10.24/lib/node_modules/github-changes/bin/index.js:453:35
    at tryCatch1 (/Users/lalit/.nvm/v0.10.24/lib/node_modules/github-changes/node_modules/bluebird/js/main/util.js:86:19)
    at Promise$_callHandler [as _callHandler] (/Users/lalit/.nvm/v0.10.24/lib/node_modules/github-changes/node_modules/bluebird/js/main/promise.js:681:13)
    at Promise$_settlePromiseFromHandler [as _settlePromiseFromHandler] (/Users/lalit/.nvm/v0.10.24/lib/node_modules/github-changes/node_modules/bluebird/js/main/promise.js:697:18)
    at Promise$_settlePromiseAt [as _settlePromiseAt] (/Users/lalit/.nvm/v0.10.24/lib/node_modules/github-changes/node_modules/bluebird/js/main/promise.js:879:14)
    at Promise$_fulfillPromises [as _fulfillPromises] (/Users/lalit/.nvm/v0.10.24/lib/node_modules/github-changes/node_modules/bluebird/js/main/promise.js:981:14)
```
