### PR TITLE
Adds support for GitHub Enterprise.

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -69,6 +69,14 @@ opts = parser
   , help: 'name of the file to output the changelog to'
   , default: 'CHANGELOG.md'
   })
+  .option('host', {
+    help: 'alternate host name to use with github enterprise'
+  , default: 'github.com'
+  })
+  .option('path-prefix', {
+    help: 'path-prefix for use with github enterprise'
+  , default: ''
+  })
   .option('verbose', {
     abbr: 'v'
   , help: 'output details'
@@ -114,6 +122,8 @@ var currentDate = moment();
 var github = new GithubApi({
   version: '3.0.0'
 , timeout: 10000
+, pathPrefix: (opts['path-prefix'] == '') ? '' : opts['path-prefix']
+, host: opts.host
 });
 
 // github auth token
@@ -221,6 +231,8 @@ var getAllCommits = function() {
     var commits = [];
     commitStream({
       token: token
+    , host: opts.host
+    , pathPrefix: (opts['path-prefix'] == '') ? '' : opts['path-prefix']
     , user: opts.owner
     , repo: opts.repository
     , sha: opts.branch
@@ -366,7 +378,7 @@ var commitFormatter = function(data) {
     if (isPull) {
       var prNumber = commit.commit.message.split('#')[1].split(' ')[0];
       var author = (commit.commit.message.split(/\#\d+\sfrom\s/)[1]||'').split('/')[0];
-      var url = "https://github.com/"+opts.owner+"/"+opts.repository+"/pull/"+prNumber;
+      var url = "https://"+opts.host+"/"+opts.owner+"/"+opts.repository+"/pull/"+prNumber;
       output += "- [#" + prNumber + "](" + url + ") " + message;
 
       if (authors.length)

--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
   },
   "dependencies": {
     "ghauth": "0.0.0",
-    "github": "0.1.12",
+    "github": "0.1.16",
     "bluebird": "1.0.3",
     "lodash": "2.4.1",
     "moment": "2.5.1",
     "nomnom": "1.6.2",
     "parse-link-header": "0.1.0",
-    "github-commit-stream": "0.0.1",
+    "github-commit-stream": "0.1.0",
     "semver": "2.2.1"
   },
   "devDependencies": {},


### PR DESCRIPTION
Fixes #32

This tool kicks ass. I used it for back-filling tags in one of our projects.. 56 releases. I couldn't imagine trying to do that by hand!

``` bash
$ github-changes --host github.fit.edu --path-prefix /api/v3 -o levilewis -r FIT-PHP-Namespace -k [sometoken] --use-commit-body -v --no-merges --only-pulls -f ~/Desktop/CHANGELOG.md
```

``` BASH
fetching commits
pulled commit data for tag -  0.11.11
....
pulled commit data for tag -  0.8.0
fetched all commits
```

Sample of output file:
![screen shot 2014-05-05 at 1 19 02 pm](https://cloud.githubusercontent.com/assets/461249/2880661/69e8c186-d479-11e3-803e-ccbbc33f5c32.png)

Let me know if you want changes to the PR. Thanks for noticing and sorry I forgot to submit. This PR requires two of the dependencies to be bumped. So, please review for any potential issues before merging :beers:
