### PR TITLE
Fetch 100 tags per page (only 1 page for now)

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -147,6 +147,7 @@ var getTags = function(){
   var tagOpts = {
     user: opts.owner
   , repo: opts.repository
+  , per_page: 100
   };
   auth();
   return github.repos.getTagsAsync(tagOpts).map(function(ref){


### PR DESCRIPTION
Per discussion at #40, this is a quick fix for [mikeal/request](/mikeal/request) that will pull in all of our tagged versions.
