### PR TITLE
added --for-tag option to generate changelog for single tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Options:
    --host              alternate host name to use with github enterprise  [api.github.com]
    --path-prefix       path-prefix for use with github enterprise
    --between-tags      only diff between these two tags, separate by 3 dots ...
+   --for-tag           only get changes for this tag
    --issue-body        (DEPRECATED) include the body of the issue (--data MUST equal 'pulls')
    --no-merges         do not include merges
    --only-merges       only include merges
@@ -131,7 +132,7 @@ github-changes -o npm -r npm -a
 
 If you want to generate a changelog within a grunt workflow, [a grunt plugin] (https://github.com/streetlight/grunt-github-changes) that can be utilized. To install:
 
-``` 
+```
 npm install grunt-github-changes --save-dev
 ```
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -95,6 +95,9 @@ opts = parser
   .option('between-tags', {
     help: 'only diff between these two tags, separate by 3 dots ...'
   })
+  .option('for-tag', {
+    help: 'only get changes for this tag'
+  })
   .option('issue-body', {
     help: '(DEPRECATED) include the body of the issue (--data MUST equal \'pulls\')'
   , flag: true
@@ -141,6 +144,8 @@ if (opts['only-pulls']) opts.merges = true;
 var betweenTags = [null, null];
 var betweenTagsNames = null;
 if (opts['between-tags']) betweenTagsNames = opts['between-tags'].split('...');
+
+var forTag = opts['for-tag'];
 
 var commitsBySha = {}; // populated when calling getAllCommits
 var currentDate = moment();
@@ -378,7 +383,8 @@ var commitFormatter = function(data) {
   var output = "## " + opts.title + "\n";
   data.forEach(function(commit){
     if (betweenTagsNames && commit.tag.date<=betweenTags[0].date) return;
-    if (betweenTagsNames && commit.tag.date>betweenTags[1].date) return;
+    if (betweenTagsNames && betweenTags[1] && commit.tag.date>betweenTags[1].date) return;
+    if (forTag && commit.tag.name !== forTag) return;
 
     var isMerge = (commit.parents.length > 1);
     var isPull = isMerge && /^Merge pull request #/i.test(commit.commit.message);


### PR DESCRIPTION
this is useful for automatic generation of github release (https://developer.github.com/v3/repos/releases/#create-a-release). So you would generate changelog for single tag, and publish new release via github api.