### PR TITLE
added --time-zone option

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -5,7 +5,7 @@ var _ = require('lodash');
 var http = require('http');
 var https = require('https');
 var domain = require('domain');
-var moment = require('moment');
+var moment = require('moment-timezone');
 var parser = require('nomnom');
 var semver = require('semver');
 var Promise = require("bluebird");
@@ -73,6 +73,11 @@ opts = parser
     abbr: 't'
   , help: 'title to appear in the top of the changelog'
   , default: 'Change Log'
+  })
+  .option('time-zone', {
+    abbr: 'z'
+  , help: 'time zone'
+  , default: 'UTC'
   })
   .option('date-format', {
     abbr: 'm'
@@ -324,7 +329,7 @@ var prFormatter = function(data) {
       } else if (pr.tag.name != currentTagName) {
         currentTagName = pr.tag.name;
         output+= "\n### " + pr.tag.name
-        output+= " " + pr.tag.date.utc().format(opts['date-format']);
+        output+= " " + pr.tag.date.tz(opts['time-zone']).format(opts['date-format']);
         output+= "\n";
       }
     }
@@ -409,7 +414,7 @@ var commitFormatter = function(data) {
       } else if (commit.tag.name != currentTagName) {
         currentTagName = commit.tag.name;
         output+= "\n### " + commit.tag.name
-        output+= " " + commit.tag.date.utc().format(opts['date-format']);
+        output+= " " + commit.tag.date.tz(opts['time-zone']).format(opts['date-format']);
         output+= "\n";
       }
     }

--- a/package.json
+++ b/package.json
@@ -7,14 +7,14 @@
     "github-changes": "./bin/index.js"
   },
   "dependencies": {
+    "bluebird": "1.0.3",
     "ghauth": "3.0.0",
     "github": "0.1.16",
-    "bluebird": "1.0.3",
+    "github-commit-stream": "0.1.0",
     "lodash": "2.4.1",
-    "moment": "2.5.1",
+    "moment-timezone": "0.5.5",
     "nomnom": "1.6.2",
     "parse-link-header": "0.1.0",
-    "github-commit-stream": "0.1.0",
     "semver": "2.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Added an option for specify the TimeZone.

### Usage

```
github-changes -o lalitkapoor -r github-changes -b master -a --only-pulls --use-commit-body -k <token> -z Asia/Tokyo
```

```
## Change Log

### upcoming (2016/08/17 17:26 +09:00)
- [#55](https://github.com/lalitkapoor/github-changes/pull/55) Update README with correct links! (@PunkChameleon)

### v1.0.2 (2016/02/22 09:53 +09:00)
- [#53](https://github.com/lalitkapoor/github-changes/pull/53) added --for-tag option to generate changelog for single tag (@ivpusic)
...
```