### PR TITLE
fix Maximum call stack size exceeded

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -364,7 +364,7 @@ var getCommitsInMerge = function(mergeCommit) {
     commitsBySha[sha].parents.forEach(function(parent){
       if (directDescendents[parent.sha]) return;
       if (store[parent.sha]) return; // don't revist commits we've explored
-      return getAllReachableCommits(parent.sha, store);
+      return setTimeout(function() {getAllReachableCommits(parent.sha, store)}, 0);
     })
   };
 


### PR DESCRIPTION
hello.
I met a problem of stackover flow as blow.
```
$ github-changes -v -o myorg-inc -r api-repo -b master -a --only-pulls --use-commit-body -z Asia/Tokyo
fetching commits
pulled commit data for tag -  1.90.0
pulled commit data for tag -  1.89.0
pulled commit data for tag -  1.81.0
 .
 .
 .
fetched 5000 commits
fetched 5100 commits
fetched 5200 commits
fetched 5300 commits
fetched all commits
error RangeError: Maximum call stack size exceeded
    at Array.forEach (native)
    at getAllReachableCommits (C:\Users\myname\AppData\Roaming\npm\node_modules\github-changes\bin\index.js:364:31)
    at C:\Users\myname\AppData\Roaming\npm\node_modules\github-changes\bin\index.js:367:14
    at Array.forEach (native)
    at getAllReachableCommits (C:\Users\myname\AppData\Roaming\npm\node_modules\github-changes\bin\index.js:364:31)
    at C:\Users\myname\AppData\Roaming\npm\node_modules\github-changes\bin\index.js:367:14
    at Array.forEach (native)
    at getAllReachableCommits (C:\Users\myname\AppData\Roaming\npm\node_modules\github-changes\bin\index.js:364:31)
    at C:\Users\myname\AppData\Roaming\npm\node_modules\github-changes\bin\index.js:367:14
    at Array.forEach (native)
stack RangeError: Maximum call stack size exceeded
    at Array.forEach (native)
    at getAllReachableCommits (C:\Users\myname\AppData\Roaming\npm\node_modules\github-changes\bin\index.js:364:31)
    at C:\Users\myname\AppData\Roaming\npm\node_modules\github-changes\bin\index.js:367:14
    at Array.forEach (native)
    at getAllReachableCommits (C:\Users\myname\AppData\Roaming\npm\node_modules\github-changes\bin\index.js:364:31)
    at C:\Users\myname\AppData\Roaming\npm\node_modules\github-changes\bin\index.js:367:14
    at Array.forEach (native)
    at getAllReachableCommits (C:\Users\myname\AppData\Roaming\npm\node_modules\github-changes\bin\index.js:364:31)
    at C:\Users\myname\AppData\Roaming\npm\node_modules\github-changes\bin\index.js:367:14
    at Array.forEach (native)

```
then, I like to suggest stackover flow workaround like this PR.

