### PR TITLE
Add trailing newline to CHANGELOG

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -345,7 +345,7 @@ var prFormatter = function(data) {
     // output += " " + moment(pr.merged_at).utc().format(opts['date-format']);
     output += "\n";
   });
-  return output.trim();
+  return output.trim() + "\n";
 };
 
 var getCommitsInMerge = function(mergeCommit) {


### PR DESCRIPTION
The `trim` method will also remove newline character.
So add it back after calling `trim`.