### PR TITLE
use global-tunnel-ng for HTTP proxy support

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -13,6 +13,10 @@ var GithubApi = require('github');
 var linkParser = require('parse-link-header');
 var ghauth = Promise.promisify(require('ghauth'));
 var commitStream = require('github-commit-stream');
+var globalTunnel = require('global-tunnel-ng');
+
+globalTunnel.initialize();
+
 
 // Increase number of concurrent requests
 http.globalAgent.maxSockets = 30;

--- a/bin/index.js
+++ b/bin/index.js
@@ -13,9 +13,9 @@ var GithubApi = require('github');
 var linkParser = require('parse-link-header');
 var ghauth = Promise.promisify(require('ghauth'));
 var commitStream = require('github-commit-stream');
-var globalTunnel = require('global-tunnel-ng');
+var globalAgent = require('global-agent');
 
-globalTunnel.initialize();
+globalAgent.bootstrap();
 
 
 // Increase number of concurrent requests

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,50 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-1.0.3.tgz",
       "integrity": "sha1-xLRBGEgC47ZKYe7tRXgnG0yL9qw="
     },
+    "boolean": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.0.2.tgz",
+      "integrity": "sha512-RwywHlpCRc3/Wh81MiCKun4ydaIFyW5Ea6JbL6sRCVx5q5irDw7pMXBUFYF/jArQ6YrG36q0kpovc9P/Kd3I4g=="
+    },
+    "core-js": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.7.0.tgz",
+      "integrity": "sha512-NwS7fI5M5B85EwpWuIwJN4i/fbisQUwLwiSNUWeXlkAZ0sbBjLEvLvFLf1uzAUV66PcEPt4xCGCmOZSxVf3xzA=="
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
+    "detect-node": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
+      "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
+    },
+    "es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
+    },
+    "escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+    },
     "ghauth": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ghauth/-/ghauth-3.0.0.tgz",
       "integrity": "sha1-gpKiTvR4mfGAo5x4DEgJVhKUvbw=",
       "requires": {
-        "application-config": "0.1.2",
-        "bl": "0.9.4",
-        "hyperquest": "1.2.0",
-        "mkdirp": "0.5.1",
-        "read": "1.0.7",
-        "xtend": "4.0.1"
+        "application-config": "~0.1.1",
+        "bl": "~0.9.4",
+        "hyperquest": "~1.2.0",
+        "mkdirp": "~0.5.0",
+        "read": "~1.0.5",
+        "xtend": "~4.0.0"
       },
       "dependencies": {
         "application-config": {
@@ -27,8 +60,8 @@
           "resolved": "https://registry.npmjs.org/application-config/-/application-config-0.1.2.tgz",
           "integrity": "sha1-MnJTO1+fg7MjqeXWQKNVi1Cls4U=",
           "requires": {
-            "application-config-path": "0.1.0",
-            "mkdirp": "0.5.1"
+            "application-config-path": "^0.1.0",
+            "mkdirp": "^0.5.1"
           },
           "dependencies": {
             "application-config-path": {
@@ -43,7 +76,7 @@
           "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
           "integrity": "sha1-RwLd9y++Ds2CeHwAwROuoZNa0Oc=",
           "requires": {
-            "readable-stream": "1.0.33"
+            "readable-stream": "~1.0.26"
           },
           "dependencies": {
             "readable-stream": {
@@ -51,10 +84,10 @@
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "integrity": "sha1-OjYN1mwbHX/UcFOJhg7aHQ9hEmw=",
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.1",
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
                 "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
+                "string_decoder": "~0.10.x"
               },
               "dependencies": {
                 "core-util-is": {
@@ -86,8 +119,8 @@
           "resolved": "https://registry.npmjs.org/hyperquest/-/hyperquest-1.2.0.tgz",
           "integrity": "sha1-OeH+9miI3Hzg3sbA3YFPb8iUStU=",
           "requires": {
-            "duplexer2": "0.0.2",
-            "through2": "0.6.5"
+            "duplexer2": "~0.0.2",
+            "through2": "~0.6.3"
           },
           "dependencies": {
             "duplexer2": {
@@ -95,7 +128,7 @@
               "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
               "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
               "requires": {
-                "readable-stream": "1.1.13"
+                "readable-stream": "~1.1.9"
               },
               "dependencies": {
                 "readable-stream": {
@@ -103,10 +136,10 @@
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "integrity": "sha1-9u73ZPUUyJ4rniMUanW6EGdW0j4=",
                   "requires": {
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.1",
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.1",
                     "isarray": "0.0.1",
-                    "string_decoder": "0.10.31"
+                    "string_decoder": "~0.10.x"
                   },
                   "dependencies": {
                     "core-util-is": {
@@ -138,8 +171,8 @@
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
               "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
               "requires": {
-                "readable-stream": "1.0.33",
-                "xtend": "4.0.1"
+                "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                "xtend": ">=4.0.0 <4.1.0-0"
               },
               "dependencies": {
                 "readable-stream": {
@@ -147,10 +180,10 @@
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "integrity": "sha1-OjYN1mwbHX/UcFOJhg7aHQ9hEmw=",
                   "requires": {
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.1",
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.1",
                     "isarray": "0.0.1",
-                    "string_decoder": "0.10.31"
+                    "string_decoder": "~0.10.x"
                   },
                   "dependencies": {
                     "core-util-is": {
@@ -199,7 +232,7 @@
           "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
           "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
           "requires": {
-            "mute-stream": "0.0.5"
+            "mute-stream": "~0.0.4"
           },
           "dependencies": {
             "mute-stream": {
@@ -226,10 +259,10 @@
       "resolved": "https://registry.npmjs.org/github-commit-stream/-/github-commit-stream-0.1.0.tgz",
       "integrity": "sha1-2823smeWcYa3DMc2ORgw2mNo16E=",
       "requires": {
-        "async": "0.2.10",
-        "parse-link-header": "0.1.0",
-        "request": "2.22.0",
-        "through": "2.3.8"
+        "async": "~0.2.9",
+        "parse-link-header": "~0.1.0",
+        "request": "~2.22.0",
+        "through": "~2.3.4"
       },
       "dependencies": {
         "async": {
@@ -242,18 +275,18 @@
           "resolved": "https://registry.npmjs.org/request/-/request-2.22.0.tgz",
           "integrity": "sha1-uIOnacxKkJVx61AEs0TEPPflFZI=",
           "requires": {
-            "aws-sign": "0.3.0",
-            "cookie-jar": "0.3.0",
-            "forever-agent": "0.5.2",
+            "aws-sign": "~0.3.0",
+            "cookie-jar": "~0.3.0",
+            "forever-agent": "~0.5.0",
             "form-data": "0.0.8",
-            "hawk": "0.13.1",
-            "http-signature": "0.10.1",
-            "json-stringify-safe": "4.0.0",
-            "mime": "1.2.11",
-            "node-uuid": "1.4.7",
-            "oauth-sign": "0.3.0",
-            "qs": "0.6.6",
-            "tunnel-agent": "0.3.0"
+            "hawk": "~0.13.0",
+            "http-signature": "~0.10.0",
+            "json-stringify-safe": "~4.0.0",
+            "mime": "~1.2.9",
+            "node-uuid": "~1.4.0",
+            "oauth-sign": "~0.3.0",
+            "qs": "~0.6.0",
+            "tunnel-agent": "~0.3.0"
           },
           "dependencies": {
             "aws-sign": {
@@ -276,9 +309,9 @@
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.0.8.tgz",
               "integrity": "sha1-CJDNEAXFzOzAudJKiAUskkQtDbU=",
               "requires": {
-                "async": "0.2.10",
-                "combined-stream": "0.0.7",
-                "mime": "1.2.11"
+                "async": "~0.2.7",
+                "combined-stream": "~0.0.4",
+                "mime": "~1.2.2"
               },
               "dependencies": {
                 "combined-stream": {
@@ -303,10 +336,10 @@
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-0.13.1.tgz",
               "integrity": "sha1-NheViCH1gxHk1/beKR/KZitBLvQ=",
               "requires": {
-                "boom": "0.4.2",
-                "cryptiles": "0.2.2",
-                "hoek": "0.8.5",
-                "sntp": "0.2.4"
+                "boom": "0.4.x",
+                "cryptiles": "0.2.x",
+                "hoek": "0.8.x",
+                "sntp": "0.2.x"
               },
               "dependencies": {
                 "boom": {
@@ -314,7 +347,7 @@
                   "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
                   "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
                   "requires": {
-                    "hoek": "0.9.1"
+                    "hoek": "0.9.x"
                   },
                   "dependencies": {
                     "hoek": {
@@ -329,7 +362,7 @@
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
                   "integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
                   "requires": {
-                    "boom": "0.4.2"
+                    "boom": "0.4.x"
                   }
                 },
                 "hoek": {
@@ -342,7 +375,7 @@
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
                   "integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
                   "requires": {
-                    "hoek": "0.9.1"
+                    "hoek": "0.9.x"
                   },
                   "dependencies": {
                     "hoek": {
@@ -360,7 +393,7 @@
               "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
               "requires": {
                 "asn1": "0.1.11",
-                "assert-plus": "0.1.5",
+                "assert-plus": "^0.1.5",
                 "ctype": "0.5.3"
               },
               "dependencies": {
@@ -420,23 +453,65 @@
         }
       }
     },
+    "global-agent": {
+      "version": "2.1.12",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-2.1.12.tgz",
+      "integrity": "sha512-caAljRMS/qcDo69X9BfkgrihGUgGx44Fb4QQToNQjsiWh+YlQ66uqYVAdA8Olqit+5Ng0nkz09je3ZzANMZcjg==",
+      "requires": {
+        "boolean": "^3.0.1",
+        "core-js": "^3.6.5",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+        }
+      }
+    },
+    "globalthis": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.1.tgz",
+      "integrity": "sha512-mJPRTc/P39NH/iNG4mXa9aIhNymaQikTrnspeCa2ZuJ+mH2QN/rXwtX3XwKrHqWgUQFbNZKtHM105aHzJalElw==",
+      "requires": {
+        "define-properties": "^1.1.3"
+      }
+    },
     "json": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/json/-/json-9.0.3.tgz",
       "integrity": "sha1-CN0O2p3aMKQNl4zIgjws5y311PE=",
       "dev": true
     },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
     "lodash": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
       "integrity": "sha1-W3cjA03aTSYuWkb7LFjXzCL3FCA="
+    },
+    "matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "requires": {
+        "escape-string-regexp": "^4.0.0"
+      }
     },
     "moment-timezone": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.5.tgz",
       "integrity": "sha1-odVBCnLBil8pPyouYocKgK1DLa4=",
       "requires": {
-        "moment": "2.19.1"
+        "moment": ">= 2.6.0"
       },
       "dependencies": {
         "moment": {
@@ -451,8 +526,8 @@
       "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.6.2.tgz",
       "integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
       "requires": {
-        "colors": "0.5.1",
-        "underscore": "1.4.4"
+        "colors": "0.5.x",
+        "underscore": "~1.4.4"
       },
       "dependencies": {
         "colors": {
@@ -467,12 +542,17 @@
         }
       }
     },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+    },
     "parse-link-header": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-0.1.0.tgz",
       "integrity": "sha1-VQP6f7LzVLsjQlXBxCHaPrBbkYU=",
       "requires": {
-        "xtend": "2.0.6"
+        "xtend": "~2.0.5"
       },
       "dependencies": {
         "xtend": {
@@ -480,8 +560,8 @@
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.0.6.tgz",
           "integrity": "sha1-XqZXptukRwacLlnFihE4ywxebO4=",
           "requires": {
-            "is-object": "0.1.2",
-            "object-keys": "0.2.0"
+            "is-object": "~0.1.2",
+            "object-keys": "~0.2.0"
           },
           "dependencies": {
             "is-object": {
@@ -494,9 +574,9 @@
               "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.2.0.tgz",
               "integrity": "sha1-zd7AKZiwkb5CvxA1rjLknxy26mc=",
               "requires": {
-                "foreach": "2.0.5",
-                "indexof": "0.0.1",
-                "is": "0.2.7"
+                "foreach": "~2.0.1",
+                "indexof": "~0.0.1",
+                "is": "~0.2.6"
               },
               "dependencies": {
                 "foreach": {
@@ -520,10 +600,46 @@
         }
       }
     },
+    "roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "requires": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      }
+    },
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
       "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+    },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
+    },
+    "serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "requires": {
+        "type-fest": "^0.13.1"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+    },
+    "type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-changes",
-  "version": "1.1.2",
+  "version": "1.1.2-proxy-1",
   "description": "generate changelog for github repos",
   "main": "./bin/index.js",
   "bin": {
@@ -16,7 +16,7 @@
     "nomnom": "1.6.2",
     "parse-link-header": "0.1.0",
     "semver": "5.4.1",
-    "global-tunnel-ng": "2.7.1"
+    "global-agent": "2.1.12"
   },
   "devDependencies": {
     "json": "^9.0.2"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "moment-timezone": "0.5.5",
     "nomnom": "1.6.2",
     "parse-link-header": "0.1.0",
-    "semver": "5.4.1"
+    "semver": "5.4.1",
+    "global-tunnel-ng": "2.7.1"
   },
   "devDependencies": {
     "json": "^9.0.2"


### PR DESCRIPTION
Adds support for HTTP proxy via [global-tunnel-ng](https://www.npmjs.com/package/global-tunnel-ng)

Environment variables `HTTP_PROXY` and `HTTPS_PROXY` are used to configure the proxy.

Resolves #66