### PR TITLE
validate tags given in --between-tags option

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -73,6 +73,11 @@ if (opts.betweenTags) {
     console.error(`Invalid value of --between-tags option: ${opts.betweenTags}. --between-tags value must contain ... (for example --between-tags 1.0.0...1.1.0)`);
     return;
   }
+  const lastThreeDotsIndex = opts.betweenTags.lastIndexOf('...');
+  if (lastThreeDotsIndex >= firstThreeDotsIndex + 3) {
+    console.error(`Invalid value of --between-tags option: ${opts.betweenTags}. --between-tags value must contain ... only once (for example --between-tags 1.0.0...1.1.0)`);
+    return;
+  }
   betweenTagsNames = opts.betweenTags.split('...');
 }
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -59,7 +59,13 @@ if (opts.onlyPulls) opts.merges = true;
 
 var betweenTags = [null, null];
 var betweenTagsNames = null;
-if (opts.betweenTags) betweenTagsNames = opts.betweenTags.split('...');
+if (opts.betweenTags) {
+  if (opts.betweenTags.length === undefined) {
+    console.error('Invalid empty value of --between-tags option. --between-tags must have a value of two tags separated by ... (for example --between-tags 1.0.0...1.1.0)');
+    return;
+  }
+  betweenTagsNames = opts.betweenTags.split('...');
+}
 
 var forTag = opts.forTag;
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -64,6 +64,10 @@ if (opts.betweenTags) {
     console.error('Invalid empty value of --between-tags option. --between-tags must have a value of two tags separated by ... (for example --between-tags 1.0.0...1.1.0)');
     return;
   }
+  if (opts.betweenTags.length <= 4) {
+    console.error(`Invalid value of --between-tags option: ${opts.betweenTags}. --between-tags value must have a minimal length of 5 (two tags separated by ... for example --between-tags 1.0.0...1.1.0)`);
+    return;
+  }
   betweenTagsNames = opts.betweenTags.split('...');
 }
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -110,6 +110,19 @@ var getTags = function(){
 
   return github.repos.listTags(tagOpts)
     .then(result => result.data)
+    .then(tagArray => {
+      if (!betweenTagsNames) {
+        return tagArray;
+      }
+      const tagNames = tagArray.map(e => e.name);
+      if (!tagNames.includes(betweenTagsNames[0])) {
+        throw new Error(`Tag ${betweenTagsNames[0]} was given as a first value of --between-tags but it doesn't exist in repository`);
+      }
+      if (!tagNames.includes(betweenTagsNames[1])) {
+        throw new Error(`Tag ${betweenTagsNames[1]} was given as a second value of --between-tags but it doesn't exist in repository`);
+      }
+      return tagArray;
+    })
     .map(function(ref){
       return github.repos.getCommit({
           owner: tagOpts.owner

--- a/bin/index.js
+++ b/bin/index.js
@@ -68,6 +68,11 @@ if (opts.betweenTags) {
     console.error(`Invalid value of --between-tags option: ${opts.betweenTags}. --between-tags value must have a minimal length of 5 (two tags separated by ... for example --between-tags 1.0.0...1.1.0)`);
     return;
   }
+  const firstThreeDotsIndex = opts.betweenTags.indexOf('...');
+  if (firstThreeDotsIndex === -1) {
+    console.error(`Invalid value of --between-tags option: ${opts.betweenTags}. --between-tags value must contain ... (for example --between-tags 1.0.0...1.1.0)`);
+    return;
+  }
   betweenTagsNames = opts.betweenTags.split('...');
 }
 


### PR DESCRIPTION
For validation/parsing of command-line option, I opted for printing to `console.error` regardless of `--verbose` option because otherwise user might be confused why the program stopped. For checking whether tags really exist, I opted for `throw new Error(...)` because it will be caught by top level `catch` inside `task` function. Maybe there is a more elegant solution but I couldn't find it.

This PR doesn't actually close issue #84 because supporting raw git repo seems out of scope for `@octokit/core` which is used to fetch info from GitHub repos.