### PR TITLE
Cannot read property 'repos' of null

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -414,8 +414,7 @@ var getGithubToken = function() {
 var task = function() {
   getGithubToken()
     .then(function(authData){
-      if (!authData.token) return;
-      token = authData.token;
+      if (authData.token) token = authData.token;
 
       github = new Octokit({
         version: '3.0.0'


### PR DESCRIPTION
In version 2.0.1, if I start the app without `--token ABC` (similar to `node bin\index.js --owner TheJavaGuy --repository rng --verbose`), I got the following error:
```
error TypeError: Cannot read property 'repos' of null
    at getTags (e:\Sors\JavaScript\github-changes\bin\index.js:101:17)
    at e:\Sors\JavaScript\github-changes\bin\index.js:432:27
    at bound (domain.js:402:14)
    at runBound (domain.js:415:12)
    at tryCatcher (e:\Sors\JavaScript\github-changes\node_modules\bluebird\js\release\util.js:16:23)
    at Promise._settlePromiseFromHandler (e:\Sors\JavaScript\github-changes\node_modules\bluebird\js\release\promise.js:512:31)
    at Promise._settlePromise (e:\Sors\JavaScript\github-changes\node_modules\bluebird\js\release\promise.js:569:18)
    at Promise._settlePromise0 (e:\Sors\JavaScript\github-changes\node_modules\bluebird\js\release\promise.js:614:10)
    at Promise._settlePromises (e:\Sors\JavaScript\github-changes\node_modules\bluebird\js\release\promise.js:694:18)
    at _drainQueueStep (e:\Sors\JavaScript\github-changes\node_modules\bluebird\js\release\async.js:138:12)
    at _drainQueue (e:\Sors\JavaScript\github-changes\node_modules\bluebird\js\release\async.js:131:9)
    at Async._drainQueues (e:\Sors\JavaScript\github-changes\node_modules\bluebird\js\release\async.js:147:5)
    at Immediate.Async.drainQueues [as _onImmediate] (e:\Sors\JavaScript\github-changes\node_modules\bluebird\js\release\async.js:17:14)
    at runCallback (timers.js:705:18)
    at tryOnImmediate (timers.js:676:5)
    at processImmediate (timers.js:658:5)
```

But, if I start it with token, it works: `node bin\index.js --owner TheJavaGuy --repository rng --token ABC --verbose`. It seems that in function `getTags`, variable `github` is null because in function `task` it is not set because of `if (!authData.token) return;`.

@lalitkapoor I can prepare PR for this if you want.