### PR TITLE
Rename default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Options:
    -o, --owner         (required) owner of the Github repository
    -r, --repository    (required) name of the Github repository
    -d, --data          (DEPRECATED) use pull requests or commits (choices: pulls, commits)  [commits]
-   -b, --branch        name of the default branch  [master]
+   -b, --branch        name of the default branch  [main]
    -n, --tag-name      tag name for upcoming release  [upcoming]
    -a, --auth          prompt to auth with Github - use this for private repos and higher rate limits
    -k, --token         need to use this or --auth for private repos and higher rate limits

--- a/bin/index.js
+++ b/bin/index.js
@@ -31,7 +31,7 @@ var opts = parser
   .requiredOption('-o, --owner <name>', '(required) owner of the Github repository')
   .requiredOption('-r, --repository <name>', '(required) name of the Github repository')
   .option('-d, --data [type]', '(DEPRECATED) use pull requests or commits (choices: pulls, commits)', 'commits')
-  .option('-b, --branch [name]', 'name of the default branch', 'master')
+  .option('-b, --branch [name]', 'name of the default branch', 'main')
   .option('-n, --tag-name [name]', 'tag name for upcoming release', 'upcoming')
   .option('-a, --auth', 'prompt to auth with Github - use this for private repos and higher rate limits')
   .option('-k, --token [token]', 'need to use this or --auth for private repos and higher rate limits')

--- a/release.sh
+++ b/release.sh
@@ -20,7 +20,7 @@ git checkout master
 npm install
 npm version $1
 VERSION=`cat package.json | json version`
-node bin/index.js -o lalitkapoor -r github-changes --only-pulls -v -a --use-commit-body --reverse-changes -n v$VERSION
+node bin/index.js -o lalitkapoor -r github-changes --only-pulls -v -a --use-commit-body --reverse-changes -n v$VERSION -b master
 git add CHANGELOG.md
 git commit --amend --no-edit
 git push origin master


### PR DESCRIPTION
Now new repositories use ``main`` instead of ``master`` in GitHub.

ref: https://github.com/github/renaming#new-repositories-use-main-as-the-default-branch-name

So I guess this script should also use ``main`` by default :-)